### PR TITLE
scikit-learn: add homepage to package.yml

### DIFF
--- a/packages/s/scikit-learn/abi_used_symbols
+++ b/packages/s/scikit-learn/abi_used_symbols
@@ -216,13 +216,13 @@ UNKNOWN:PyUnicode_Type
 UNKNOWN:Py_EnterRecursiveCall
 UNKNOWN:Py_GetVersion
 UNKNOWN:Py_LeaveRecursiveCall
-UNKNOWN:Py_OptimizeFlag
 UNKNOWN:_PyBytes_Join
 UNKNOWN:_PyDict_GetItem_KnownHash
 UNKNOWN:_PyDict_NewPresized
 UNKNOWN:_PyDict_Pop
 UNKNOWN:_PyDict_SetItem_KnownHash
 UNKNOWN:_PyGen_SetStopIterationValue
+UNKNOWN:_PyInterpreterState_GetConfig
 UNKNOWN:_PyList_Extend
 UNKNOWN:_PyObject_CallFunction_SizeT
 UNKNOWN:_PyObject_GC_New

--- a/packages/s/scikit-learn/package.yml
+++ b/packages/s/scikit-learn/package.yml
@@ -1,8 +1,9 @@
 name       : scikit-learn
 version    : 1.0.2
-release    : 19
+release    : 20
 source     :
     - https://github.com/scikit-learn/scikit-learn/archive/refs/tags/1.0.2.tar.gz : 34471662f0e5ba8d2c799391338c6f976680cc66b715e00db0c7589f4f371bc4
+homepage   : https://github.com/scikit-learn/scikit-learn
 license    : BSD-3-Clause
 component  : programming.python
 summary    : Python module for machine learning

--- a/packages/s/scikit-learn/pspec_x86_64.xml
+++ b/packages/s/scikit-learn/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>scikit-learn</Name>
+        <Homepage>https://github.com/scikit-learn/scikit-learn</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clifford Red</Name>
+            <Email>a108384@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -1241,12 +1242,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-02-16</Date>
+        <Update release="20">
+            <Date>2024-07-06</Date>
             <Version>1.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clifford Red</Name>
+            <Email>a108384@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Add homepage reference to package.yml


**Test Plan**

Verified homepage reference in package.yml.  
Built and installed package, installed pytest and tested per scikit-learn.org instructions. Performed basic pytests, received the same results before and after the update.

**Checklist**

- [X ] Package was built and tested against unstable
